### PR TITLE
Validator's default value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "google/recaptcha": "~1.2.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-4": {
@@ -29,5 +29,11 @@
     "psr-4": {
       "brussens\\yii2\\extensions\\recaptcha\\test\\": "test/"
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    }
+  ]
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -52,7 +52,7 @@ class Validator extends \yii\validators\Validator
     protected function validateValue($value)
     {
         $request = Yii::$app->getRequest();
-        $value = $request->post('g-recaptcha-response');
+        $value = $request->post('g-recaptcha-response', $value);
         if(!$value) {
             return [Yii::t('yii', '{attribute} cannot be blank.'), []];
         }


### PR DESCRIPTION
`Validator` uses attribute's value as default in case 'g-recaptcha-response' is not present int the request. It's going to help to get rid of duplication of the token in custom requests, e.g. RESTful API requests.